### PR TITLE
Fix hardcoded PORT configurable via .env var. #193

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite --host",
     "build": "vite build",
     "preview": "vite preview",
-    "start": "vite build && cd server && bun run server.ts",
+    "start": "vite build && bun run ./server/server.ts",
     "lint": "eslint . --ext js,jsx,ts,tsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier --write ."
   },
@@ -17,7 +17,6 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
-    "@types/lodash": "^4.17.0",
     "@vidstack/react": "next",
     "axios": "^1.6.0",
     "express": "^4.19.2",
@@ -32,7 +31,8 @@
     "react-select": "^5.8.0",
     "styled-components": "^6.1.0",
     "swiper": "^11.0.7",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+	"dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/server/server.ts
+++ b/server/server.ts
@@ -2,13 +2,14 @@
 import express from 'express';
 import path from 'path';
 import os from 'os';
+import 'dotenv/config'; // Load environment variables from .env
+
 
 // Initialize Express app
 const app = express();
 
 // Configuration settings
-// TODO const PORT = import.meta.env.VITE_PORT || 5173;
-const PORT = 5173;
+const PORT = process.env.VITE_PORT || 5173; // get VITE_PORT value from .env
 const DIST_DIR = path.join(__dirname, '../dist');
 const INDEX_FILE = path.join(DIST_DIR, 'index.html');
 


### PR DESCRIPTION
Fix hardcoded PORT configurable via .env var. #193

Added : "dotenv": "^16.4.5" to package.json
Added : "import 'dotenv/config'; // Load environment variables from .env" to ./server/server.ts

Fixed : "start": "vite build && bun run ./server/server.ts",
